### PR TITLE
Moved whitenoise dep to base.txt

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,3 +6,4 @@ docutils>=0.12,<0.13
 Markdown>=2.6.6,<2.7
 psycopg2>=2.6.1,<2.7
 pytest-django>=2.9.1,<2.10
+whitenoise>=3.0,<4.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,4 +1,3 @@
 -r base.txt
 
 gunicorn>=19.4.5,<19.5
-whitenoise>=3.0,<4.0


### PR DESCRIPTION
Since the local 'django-admin runserver' uses wsgi.py the
whitenoise plugin needs to be installed for all environments,
not just production.
